### PR TITLE
Fix an issue with loading data from page to page

### DIFF
--- a/client/models/GuideCollection.coffee
+++ b/client/models/GuideCollection.coffee
@@ -5,7 +5,7 @@ DominoCollection = require './DominoCollection'
 module.exports = class GuideCollection extends DominoCollection
   url: -> "/tasks"
 
-  groupByCategory: ->
+  guidesByCategory: ->
     _.reduce @models, ((memo, m) =>
       category = m.category || 'extras'
       if memo[category]?
@@ -16,3 +16,6 @@ module.exports = class GuideCollection extends DominoCollection
         _.merge(memo, c)
       memo
     ), {}
+
+  guides: ->
+    _.map @models, (guide) -> new Guide(guide)

--- a/client/pages/Footprint/Footprint.view.coffee
+++ b/client/pages/Footprint/Footprint.view.coffee
@@ -14,10 +14,12 @@ module.exports = React.createClass
     guides: []
 
   componentWillMount: ->
-    guides = new GuideCollection
-    guides.on "sync", =>
+    coll = new GuideCollection
+    coll.on "sync", =>
       if @isMounted()
-        @setState categorizedGuides: guides.groupByCategory()
+        @setState categorizedGuides: coll.guidesByCategory()
+
+    @setState categorizedGuides: coll.guidesByCategory()
 
   render: ->
     locationData = [{name: "San Francisco", value: 1}, {name: "New York", value: 2}]

--- a/client/pages/Guides/Guides.view.coffee
+++ b/client/pages/Guides/Guides.view.coffee
@@ -31,11 +31,12 @@ module.exports = React.createClass
     guides: @props.guides
 
   componentWillMount: ->
-    guides = new GuideCollection
-    guides.on "sync", =>
-      _guides = _.map guides.models, (guide) -> new Guide(guide)
+    coll = new GuideCollection
+    coll.on "sync", =>
       if @isMounted()
-        @setState guides: _guides
+        @setState guides: coll.guides()
+
+    @setState guides: coll.guides()
 
   componentDidMount: ->
     anchor = @refs.anchor.getDOMNode()


### PR DESCRIPTION
If the Guides were already loaded into the guide collection, the
sync callback wasn't getting called on the new page load. This
caused the data to never show up.

This change just sets the data based on existing data in the Guides
Collection if there is any.

Also, I moved more logic into the collection and renamed the methods
to represent that they return Guide objects instead of just plan
objects.
