### PR TITLE
Move category definition to the middleware

### DIFF
--- a/client/components/GuidePreview/GuidePreview.view.coffee
+++ b/client/components/GuidePreview/GuidePreview.view.coffee
@@ -1,10 +1,10 @@
 {div, h2, p, span} = React.DOM
+Categories = require '../../models/singletons/Categories'
 
 module.exports = React.createClass
   displayName: 'GuidePreview'
   getDefaultProps: ->
     customClass: ''
-    category: {}
 
   viewGuide: ->
     page "/guide/#{@props.guide.id}"
@@ -14,15 +14,16 @@ module.exports = React.createClass
     summary = guide.intro?.caption
     preview_bg = guide.photos?[0]
     recommended = guide.recommended
+    color = Categories.colorFor(guide.category)
 
     style = {}
-    style.borderColor = @props.category.color
+    style.borderColor = color
     if preview_bg
       style.backgroundImage = "url(#{preview_bg})"
 
     div {className: "guide-preview #{@props.customClass}", onClick: @viewGuide, style: style},
       if recommended
-        span {className: "guide-preview-recommended", style: { backgroundColor: @props.category.color }}, "Recommended"
+        span {className: "guide-preview-recommended", style: { backgroundColor: color }}, "Recommended"
       div {className: "guide-preview-content"},
         h2 {className: "guide-preview-title"}, guide.title
         p {className: "guide-preview-summary"}, summary

--- a/client/middleware/categories.coffee
+++ b/client/middleware/categories.coffee
@@ -1,0 +1,7 @@
+Categories = require '../models/singletons/Categories'
+
+module.exports = (ctx, next) ->
+  if Categories.categories() == {}
+    Categories._firebase().once 'value', (-> next())
+  else
+    next()

--- a/client/models/CategoryCollection.coffee
+++ b/client/models/CategoryCollection.coffee
@@ -4,4 +4,7 @@ DominoCollection = require './DominoCollection'
 module.exports = class CategoryCollection extends DominoCollection
   url: -> "/categories"
 
+  colorFor: (name) ->
+    @loaded && @models[name].color
+
   categories: -> @models

--- a/client/models/DominoCollection.coffee
+++ b/client/models/DominoCollection.coffee
@@ -10,8 +10,10 @@ module.exports = class DominoCollection extends Events
 
     @firebase = opts.firebase
     @models = opts.models || {}
+    @loaded = false
 
     @_firebase().on 'value', (snap) =>
       if snap
         @models = snap.val()
+        @loaded = true
         @trigger('sync')

--- a/client/models/singletons/Categories.coffee
+++ b/client/models/singletons/Categories.coffee
@@ -1,0 +1,3 @@
+CategoryCollection = require '../CategoryCollection'
+
+module.exports = new CategoryCollection

--- a/client/pages/Guides/Guides.view.coffee
+++ b/client/pages/Guides/Guides.view.coffee
@@ -3,7 +3,6 @@
 _ = require 'lodash'
 Guide = require '../../models/Guide'
 GuideCollection = require '../../models/GuideCollection'
-CategoryCollection = require '../../models/CategoryCollection'
 DropdownComponent = require '../../components/Dropdown/Dropdown.view'
 NavBar = require '../../components/NavBar/NavBar.view'
 GuidePreview = require '../../components/GuidePreview/GuidePreview.view'
@@ -28,11 +27,9 @@ module.exports = React.createClass
   displayName: 'Guides'
   getDefaultProps: ->
     guides: []
-    categories: {}
 
   getInitialState: ->
     guides: @props.guides
-    categories: @props.categories
 
   componentWillMount: ->
     coll = new GuideCollection
@@ -40,14 +37,8 @@ module.exports = React.createClass
       if @isMounted()
         @setState guides: coll.guides()
 
-    categoryColl = new CategoryCollection
-    categoryColl.on "sync", =>
-      if @isMounted()
-        @setState categories: categoryColl.categories()
-
     @setState
       guides: coll.guides()
-      categories: categoryColl.categories()
 
   componentDidMount: ->
     anchor = @refs.anchor.getDOMNode()
@@ -85,7 +76,6 @@ module.exports = React.createClass
                 new GuidePreview
                   key: "guide#{guide.id}"
                   guide: guide
-                  category: @state.categories[guide.category()]
                   customClass: posClass(idx)
           else
             new LoadingIcon

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -33,6 +33,7 @@ Router = React.createClass
 routes =
   middleware: [
     ["*", require('./middleware/authentication')]
+    ["*", require('./middleware/categories')]
   ]
   pages:[
     ["/", require('./pages/Splash/Splash.view'), 'splash']


### PR DESCRIPTION
Categories don't change often and we use them throughout the site. It
seemed unnecessary to have to make them a passed dependency for each
react component instead of just being able to reference the information
as necessary from an already defined instance.

This moves the categories instance into a single instance and uses the
middleware layer to make sure that it's loaded before the site loads
