### PR TITLE
Change the guide headers to better match the design

### DIFF
--- a/client/css/app.styl
+++ b/client/css/app.styl
@@ -61,7 +61,10 @@ h2
 
 .guide-module-header
   margin-bottom 5px
-  font-variant small-caps
+  text-transform uppercase
+  font-weight bold
+  letter-spacing 3.11px
+  font-size 18px
 
 .guide-module-subheader
   margin -5px 0 0 0


### PR DESCRIPTION
small-caps isn't a great way to capitalize everything because the baseline of the letters changes dramatically. This causes it to not match up well with slashes and question marks, for example, because the baseline height is different. I'm not sure if that was intended, but it doesn't look like the design so I changed it.
