### PR TITLE
Add an endpoint for retching appointments as CSV (2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mockfirebase": "^0.3.0",
     "moment": "^2.7.0",
     "nib": "^1.0.2",
+    "nice-json2csv": "^0.1.3",
     "nodemon": "^1.0.14",
     "q": "^1.1.0",
     "request": "^2.47.0",

--- a/server/Appointments.coffee
+++ b/server/Appointments.coffee
@@ -1,0 +1,19 @@
+_ = require 'lodash'
+request = require 'request'
+
+URL = "#{process.env.FIREBASE_URL}/answers.json"
+
+fetchJSON = (callback) ->
+  options =
+    uri: URL
+    json: true
+
+  request options, (error, response, body) ->
+    if error
+      callback 500, [{ error: JSON.stringify(error), response: JSON.stringify(response) }]
+    else if response.statusCode == 200
+      callback 200, _.values body
+    else
+      callback response.statusCode, { error: 'unknown error' }
+
+module.exports = fetchJSON

--- a/start.coffee
+++ b/start.coffee
@@ -3,11 +3,13 @@ compress = require 'compression'
 staticFiles = require 'serve-static'
 http = require 'http'
 bodyParser = require('body-parser')
+json2csv = require 'nice-json2csv'
 {join} = require 'path'
 
 AmazonProducts = require './server/AmazonProducts'
 QuestionnaireEmail = require './server/QuestionnaireEmail'
 YelpListings = require './server/YelpListings'
+Appointments = require './server/Appointments'
 
 PORT = Number(process.env.PORT || 8080);
 
@@ -17,6 +19,7 @@ app.disable 'x-powered-by'
 app.use compress()
 app.use staticFiles './public'
 app.use bodyParser.json()
+app.use json2csv.expressDecorator
 
 app.use (err, req, res, next) ->
   console.error err.stack
@@ -39,6 +42,10 @@ app.post "/questionnaire-email", (req, res) ->
       res.status(502).send("Server errored out while trying to send email.")
     else
       res.status(201).send(data.json)
+
+app.get "/appointments.csv", (req, res) ->
+  Appointments (statusCode, data) ->
+    res.status(statusCode).csv(data, "appointments.csv")
 
 # page.js - client-side routing
 app.get '/*', (req, res) ->


### PR DESCRIPTION
Pretty straight forward. Just reads the JSON and serves it up using
json2csv.

There are some security concerns with exposing the appointments in
this way. We need to look at protecting that data in Firebase, but this is mergeable for now.
