### PR TITLE
Rough first pass at page titles

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset='utf-8' />
   <meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1' />
+  <title>Domino - Change the world, one step at a time</title>
   <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600|Montserrat:400,700' rel='stylesheet' type='text/css'>
   <link rel='stylesheet' href='/vendor/slick/slick.css'>
   <link href='https://api.tiles.mapbox.com/mapbox.js/v1.6.4/mapbox.css' rel='stylesheet'>

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -16,6 +16,8 @@ addPage = (route) ->
   page url, (ctx) =>
     # Set the body class based on the current page
     document.querySelector('body').className = ['body', route[2]].filter(Boolean).join('-')
+    document.title = "Domino - Change the world, one step at a time: #{route[2]}"
+
     # Scroll the window to the top each time a page gets shown
     window.scrollTo(0, 0)
 


### PR DESCRIPTION
For now, I've just set a standard page title and used the name of
the page at the end. I think a better solution would be to have
custom page titles based on the route or the guide properties.

Hoever, there is a bunch of work that should be done for SEO support
and I think that could be done during the cycle.

Example:
![image](https://cloud.githubusercontent.com/assets/3384/5350641/e3853dfc-7efc-11e4-8334-12feed9fa94e.png)

Per #128
