### PR TITLE
Default the log in bar to closed

### DIFF
--- a/client/components/AuthBar/AuthBar.view.coffee
+++ b/client/components/AuthBar/AuthBar.view.coffee
@@ -39,9 +39,30 @@ RePromptMixin =
       # Remove the attention class after 2 seconds
       setTimeout(@resetAttention, 2000)
 
+CloseFromKeyboardMixin =
+
+  _closeOnEsc: (e) ->
+    if e.keyCode == 27
+      @resetState()
+
+  _setListener: ->
+    if @state.expanded
+      document.addEventListener 'keyup', @_closeOnEsc
+    else
+      document.removeEventListener 'keyup', @_closeOnEsc
+
+  componentDidMount: ->
+    @_setListener()
+
+  componentDidUpdate: ->
+    @_setListener()
+
+  componentWillUnmount: ->
+    document.removeEventListener 'keyup', @_closeOnEsc
+
 module.exports = React.createClass
   displayName: 'AuthBar'
-  mixins: [AuthMixin, RePromptMixin]
+  mixins: [AuthMixin, RePromptMixin, CloseFromKeyboardMixin]
 
   getInitialState: ->
     closed: true

--- a/client/test/components/AuthBar/ViewTest.coffee
+++ b/client/test/components/AuthBar/ViewTest.coffee
@@ -5,6 +5,7 @@ h = require "../../helpers"
 describe "AuthBar", ->
   it "renders the auth bar", () ->
     instance = ReactTestUtils.renderIntoDocument(AuthBar())
+    instance.setState({ closed: false })
 
     h.classOccurs instance, 'auth-bar', 1
 


### PR DESCRIPTION
Closes #169

Also, allows us to use the esc key to close the login prompt, per Carson's suggestions.
