### PR TITLE
Add support for a text heading

### DIFF
--- a/client/components/Text/Text.view.coffee
+++ b/client/components/Text/Text.view.coffee
@@ -1,4 +1,4 @@
-{div, p} = React.DOM
+{div, h2, p} = React.DOM
 _ = require 'lodash'
 Autolinker = require 'autolinker'
 
@@ -6,9 +6,15 @@ module.exports = React.createClass
   displayName: 'Text'
 
   render: ->
-    text = @props.content
+    if typeof @props.content == 'string'
+      text = @props.content
+    else
+      {heading, text} = @props.content
+
     return false if _.isEmpty text
 
     div {className: 'guide-module guide-module-text'},
+      if heading
+        h2 {className: 'guide-module-header'}, heading
       div {className: 'guide-module-content'},
         p {className: 'text-content', dangerouslySetInnerHTML: {"__html": Autolinker.link(text)}}


### PR DESCRIPTION
This supports the text module content as a string, or as an object
that contains a text and heading property

Closes #198
