### PR TITLE
Show login prompt after user returns to site

### DIFF
--- a/client/components/AuthBar/AuthBar.styl
+++ b/client/components/AuthBar/AuthBar.styl
@@ -10,7 +10,7 @@ zIndex = 1200
     opacity 0
 
 .auth-bar
-  position absolute
+  position fixed
   top 0
   left 0
   right 0
@@ -77,7 +77,6 @@ zIndex = 1200
     opacity 1
 
 .auth-bar.auth-bar-expanded
-  position fixed
   min-height 100%
 
   .auth-bar-content-expanded

--- a/client/components/Layout/Layout.view.coffee
+++ b/client/components/Layout/Layout.view.coffee
@@ -1,5 +1,6 @@
 {div, p, a, span, br} = React.DOM
 
+auth = require '../../auth'
 NewsletterSignup = require '../NewsletterSignupForm/NewsletterSignupForm.view'
 Footer = require '../Footer/Footer.view'
 
@@ -7,6 +8,17 @@ module.exports = React.createClass
   displayName: 'Layout'
   getDefaultProps: ->
     showNewsletterSignup: false
+
+  handleLinkClick: (e) ->
+    if e.target && e.target.target == '_blank'
+      auth.prompt()
+
+  componentWillMount: ->
+    $('body').on 'click', 'a', @handleLinkClick
+
+  componentWillUnmount: ->
+    $('body').off 'click', 'a', @handleLinkClick
+
   render: ->
     div {className: "page page-#{@props.name}"},
       div {className: "container"},


### PR DESCRIPTION
This actually shows the login prompt when the user clicks on any link
that has a target of "_blank", it just happens that the user won't
see it until they come back to the site.

The autolinker that we use automatically adds target="_blank" to
the links that it creates, so for all standard text links, this is
covered.

For all other links, we need to manually add target="_blank" to them.

Closes #196
