### PR TITLE
Removing impact scores from the guide preview panel in guides page

### DIFF
--- a/client/components/GuidePreview/GuidePreview.view.coffee
+++ b/client/components/GuidePreview/GuidePreview.view.coffee
@@ -40,6 +40,3 @@ module.exports = React.createClass
       div {className: "guide-preview-content"},
         h2 {className: "guide-preview-title"}, guide.title
         p {className: "guide-preview-summary"}, summary
-        div {className: "guide-preview-impact-score"},
-          new ImpactScore score: @props.guide.score(), color: color
-          span {className: "impact-text"}, "impact"


### PR DESCRIPTION
For #220 
