### PR TITLE
Remove the Questionnaire CTA header

### DIFF
--- a/client/components/Questionnaire/CallToAction.view.coffee
+++ b/client/components/Questionnaire/CallToAction.view.coffee
@@ -23,11 +23,9 @@ module.exports = React.createClass
 
   render: ->
     return false unless hasValidData(@props.guide)
-    title = @props.guide.get('title')
     typeforms = @props.content.typeforms
 
     div {className: 'guide-module'},
-      h2 {className: 'guide-module-header'}, title
       div {className: 'guide-module-content guide-module-cta'},
         h2 {className: 'cta-header'}, "Ready for a free, no-obligation quote?"
         if typeforms


### PR DESCRIPTION
We were just accessing the Guide's title as the Questionnaire CTA title, so merely clearing the title from the database would remove it from the Intro module as well. This just removes the dependency altogether until we require headers for it – in which case, we'll use a separate key in the database.
