### PR TITLE
Allow the CTA to have a custom header

### DIFF
--- a/client/components/Questionnaire/CallToAction.view.coffee
+++ b/client/components/Questionnaire/CallToAction.view.coffee
@@ -3,27 +3,22 @@ TypeFormTrigger = require '../../components/TypeFormTrigger/TypeFormTrigger.view
 auth = require '../../auth'
 _ = require 'lodash'
 
-hasValidData = (guide) ->
-  return false unless guide
-  return false if _.isEmpty guide.get('questionnaire')
-  true
-
 module.exports = React.createClass
   displayName: 'CallToAction'
   getDefaultProps: ->
-    content: {}
+    content:
+      heading: "Ready for a free, no-obligation quote?"
 
   viewQuestionnaire: ->
     mixpanel.track 'View Questionnaire', guide_id: @props.guideId
     page "/guides/#{@props.guide.id}/questionnaire"
 
   render: ->
-    return false unless hasValidData(@props.guide)
     typeforms = @props.content.typeforms
 
     div {className: 'guide-module'},
       div {className: 'guide-module-content guide-module-cta'},
-        h2 {className: 'cta-header'}, "Ready for a free, no-obligation quote?"
+        h2 {className: 'cta-header'}, @props.content.heading
         if typeforms
           div {className: 'cta-buttons'},
             typeforms.map (typeform, idx) ->


### PR DESCRIPTION
This simply changes the CTA module to allow for a custom header
from the Firebase data. I've also removed some of the old code
regarding Questionnaire that is no longer necessary.

Per #260
