### PR TITLE
Trigger repositioning when page is loaded

### DIFF
--- a/client/mixins/FloatingSidebarMixin.coffee
+++ b/client/mixins/FloatingSidebarMixin.coffee
@@ -35,4 +35,7 @@ module.exports =
     @removeSidebarPositioning()
 
   componentDidMount: ->
+    setTimeout =>
+      @onScrollEventHandler()
+    , 1000
     @setupSidebarPositioning()


### PR DESCRIPTION
Sidebar appears to be broken when the user reaches a guide page from city page.
This is because Navbar and other elements are loaded for the first time
and this messes up the sidebar positioning. Hence, triggering sidebar on
page load after a second.

Per #271 
